### PR TITLE
Update bootstrap-table-fixed-columns.js (fix issue #28)

### DIFF
--- a/bootstrap-table-fixed-columns.js
+++ b/bootstrap-table-fixed-columns.js
@@ -10,6 +10,10 @@
         fixedColumns: false,
         fixedNumber: 1
     });
+    
+    $.fn.hasHorizontalScrollBar = function() {
+        return this.get(0) ? this.get(0).scrollWidth > this.innerWidth() : false;
+    };
 
     var BootstrapTable = $.fn.bootstrapTable.Constructor,
         _initHeader = BootstrapTable.prototype.initHeader,
@@ -131,8 +135,12 @@
     BootstrapTable.prototype.fitBodyColumns = function () {
         var that = this,
             top = -(parseInt(this.$el.css('margin-top')) - 2),
-            // the fixed height should reduce the scorll-x height
-            height = this.$tableBody.height() - 14;
+            height = 0;
+
+        // the fixed height should reduce the scorll-x height
+        if (this.$tableBody.hasHorizontalScrollBar()) {
+            height = this.$tableBody.height() - 19;
+        }
 
         if (!this.$body.find('> tr[data-index]').length) {
             this.$fixedBody.hide();

--- a/bootstrap-table-fixed-columns.js
+++ b/bootstrap-table-fixed-columns.js
@@ -139,7 +139,7 @@
 
         // the fixed height should reduce the scorll-x height
         if (this.$tableBody.hasHorizontalScrollBar()) {
-            height = this.$tableBody.height() - 19;
+            height = this.$tableBody.height() - 18;
         }
 
         if (!this.$body.find('> tr[data-index]').length) {

--- a/bootstrap-table-fixed-columns.js
+++ b/bootstrap-table-fixed-columns.js
@@ -10,7 +10,7 @@
         fixedColumns: false,
         fixedNumber: 1
     });
-    
+
     $.fn.hasHorizontalScrollBar = function() {
         return this.get(0) ? this.get(0).scrollWidth > this.innerWidth() : false;
     };
@@ -77,7 +77,10 @@
             var $tr = $(this).clone(),
                 $tds = $tr.find('td');
 
-            $tr.html('');
+            var dataIndex = $tr.attr("data-index");
+            $tr = $("<tr></tr>");
+            $tr.attr("data-index", dataIndex);
+            
             var end = that.options.fixedNumber;
             if (rowspan > 0) {
                 --end;


### PR DESCRIPTION
When there is too few columns and the plugin up, no horizontal scroll is shown, but the last line of the table is not well displayed then due to -14 height.

Fix height wich hide the horizontal scroll.